### PR TITLE
added -run-link-static option

### DIFF
--- a/packages/ddc-build/DDC/Build/Builder.hs
+++ b/packages/ddc-build/DDC/Build/Builder.hs
@@ -24,7 +24,10 @@ data BuilderConfig
 
           -- | Directory that holds the shared objects for the runtime
           --   system and base library.
-        , builderConfigBaseLibDir       :: FilePath }
+        , builderConfigBaseLibDir       :: FilePath
+
+          -- | Runtime library link with.
+        , builderConfigLibFile          :: FilePath -> FilePath -> FilePath }
 
 
 -- | Actions to use to invoke external compilation tools.
@@ -207,7 +210,7 @@ builder_X8632_Darwin config
                 [ "gcc -m32" 
                 , "-o", binFile
                 , intercalate " " oFiles
-                , builderConfigBaseLibDir config </> "libddc-runtime.dylib" ]
+                , builderConfigBaseLibDir config </> builderConfigLibFile config "libddc-runtime.a" "libddc-runtime.dylib" ]
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -262,7 +265,7 @@ builder_X8664_Darwin config
                 [ "gcc -m64" 
                 , "-o", binFile
                 , intercalate " " oFiles
-                , builderConfigBaseLibDir config </> "libddc-runtime.dylib" ]
+                , builderConfigBaseLibDir config </> builderConfigLibFile config "libddc-runtime.a" "libddc-runtime.dylib" ]
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -317,7 +320,7 @@ builder_X8632_Linux config
                 [ "gcc -m32" 
                 , "-o", binFile
                 , intercalate " " oFiles
-                , builderConfigBaseLibDir config </> "libddc-runtime.so" ]
+                , builderConfigBaseLibDir config </> builderConfigLibFile config "libddc-runtime.a" "libddc-runtime.so" ]
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -371,7 +374,7 @@ builder_X8664_Linux config
                 [ "gcc -m64"
                 , "-o", binFile
                 , intercalate " " oFiles
-                , builderConfigBaseLibDir config </> "libddc-runtime.so" ]
+                , builderConfigBaseLibDir config </> builderConfigLibFile config "libddc-runtime.a" "libddc-runtime.so" ]
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -424,7 +427,7 @@ builder_PPC32_Linux config
                 [ "gcc -m32" 
                 , "-o", binFile
                 , intercalate " " $ map normalise oFiles
-                , builderConfigBaseLibDir config </> "libddc-runtime.so" ]
+                , builderConfigBaseLibDir config </> builderConfigLibFile config "libddc-runtime.a" "libddc-runtime.so" ]
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -479,7 +482,7 @@ builder_X8632_Cygwin config
                 [ "gcc-4 -m32" 
                 , "-o", normalise binFile
                 , intercalate " " $ map normalise oFiles
-                , normalise $ builderConfigBaseLibDir config </> "libddc-runtime.a" ]
+                , normalise $ builderConfigBaseLibDir config </> "libddc-runtime.a" ] -- configRuntimeLinkStrategy is ignored
 
         , buildLdLibStatic
                 = \oFiles libFile
@@ -532,7 +535,7 @@ builder_X8632_Mingw config
                 [ "gcc -m32" 
                 , "-o", normalise binFile
                 , intercalate " " $ map normalise oFiles
-                , normalise $ builderConfigBaseLibDir config </> "libddc-runtime.a" ]
+                , normalise $ builderConfigBaseLibDir config </> "libddc-runtime.a" ] -- configRuntimeLinkStrategy is ignored
 
         , buildLdLibStatic
                 = \oFiles libFile

--- a/packages/ddc-driver/DDC/Driver/Config.hs
+++ b/packages/ddc-driver/DDC/Driver/Config.hs
@@ -6,7 +6,8 @@ module DDC.Driver.Config
         , defaultConfigPretty
         , prettyModeOfConfig
         
-        , ViaBackend    (..))
+        , ViaBackend    (..)
+        , RuntimeLinkStrategy (..))
 where
 import DDC.Build.Builder                        
 import DDC.Core.Simplifier              (Simplifier)
@@ -39,6 +40,9 @@ data Config
 
           -- | Runtime system configuration
         , configRuntime                 :: Salt.Config
+
+          -- | Linking strategy for the runtime.
+        , configRuntimeLinkStrategy     :: RuntimeLinkStrategy
 
           -- | The builder to use for the target architecture
         , configBuilder                 :: Builder
@@ -142,3 +146,12 @@ data ViaBackend
         | ViaLLVM
         deriving Show
 
+
+
+data RuntimeLinkStrategy
+        -- | Use the platform's default strategy.
+        = LinkDefault
+
+        -- | Link the runtime statically.
+        | LinkStatic
+        deriving (Show, Eq)

--- a/packages/ddc-driver/DDC/Driver/Stage.hs
+++ b/packages/ddc-driver/DDC/Driver/Stage.hs
@@ -9,6 +9,7 @@
 module DDC.Driver.Stage
         ( Config        (..)
         , ViaBackend    (..)
+        , RuntimeLinkStrategy (..)
 
           -- * Tetra stages
         , stageSourceTetraLoad

--- a/packages/ddc-tools/src/ddc-main/DDC/Main/Args.hs
+++ b/packages/ddc-tools/src/ddc-main/DDC/Main/Args.hs
@@ -110,7 +110,11 @@ parseArgs args config
         | "-run-heap" : bytes : rest    <- args
         , all isDigit bytes
         = parseArgs rest
-        $ config  { configRuntimeHeapSize = read bytes }
+        $ config { configRuntimeHeapSize = read bytes }
+
+        | "-run-link-static" : rest    <- args
+        = parseArgs rest
+        $ config { configRuntimeLinkStrategy = LinkStatic }
 
         -- Parsing ------------------------------
         | "-parse" : file : rest        <- args

--- a/packages/ddc-tools/src/ddc-main/DDC/Main/Config.hs
+++ b/packages/ddc-tools/src/ddc-main/DDC/Main/Config.hs
@@ -2,10 +2,11 @@
 
 -- | Define the command line configuation arguments.
 module DDC.Main.Config
-        ( Mode         (..)
-        , OptLevel     (..)
-        , D.ViaBackend (..)
-        , Config       (..)
+        ( Mode                (..)
+        , OptLevel            (..)
+        , D.ViaBackend        (..)
+        , D.RuntimeLinkStrategy (..)
+        , Config              (..)
 
         , getDefaultConfig
         , defaultBuilderConfig)
@@ -143,6 +144,9 @@ data Config
           -- | Default size of heap for compiled program.
         , configRuntimeHeapSize :: Integer
 
+          -- | Strategy for linking the runtime.
+        , configRuntimeLinkStrategy :: D.RuntimeLinkStrategy
+
           -- Intermediates -------------
         , configKeepLlvmFiles   :: Bool
         , configKeepSeaFiles    :: Bool
@@ -192,6 +196,7 @@ getDefaultConfig
  
             -- Runtime ------------------
           , configRuntimeHeapSize = 65536
+          , configRuntimeLinkStrategy = D.LinkDefault
  
             -- Intermediates ------------
           , configKeepLlvmFiles   = False
@@ -214,5 +219,5 @@ defaultBuilderConfig :: Config -> BuilderConfig
 defaultBuilderConfig config
         = BuilderConfig
         { builderConfigBaseSrcDir = configBaseDir config 
-        , builderConfigBaseLibDir = configBaseDir config </> "build" }
-
+        , builderConfigBaseLibDir = configBaseDir config </> "build"
+        , builderConfigLibFile    = \static dynamic -> if configRuntimeLinkStrategy config == D.LinkStatic then static else dynamic }

--- a/packages/ddc-tools/src/ddc-main/DDC/Main/Help.hs
+++ b/packages/ddc-tools/src/ddc-main/DDC/Main/Help.hs
@@ -56,6 +56,7 @@ help    = unlines
         , "     -print-basedir         Print directory holding the runtime and base libraries."
         , "     -print-builder         Print external builder info for this platform."
         , "     -run-heap   BYTES      Size of the fixed runtime heap.  (65536)"
+        , "     -run-link-static       Force the runtime to be linked statically."
         , ""
         , "Optimisation and Transformation"
         , "     -O0                    No optimisations.                (default)"

--- a/packages/ddc-tools/src/ddc-main/Main.hs
+++ b/packages/ddc-tools/src/ddc-main/Main.hs
@@ -219,7 +219,7 @@ getDriverConfig config filePath
  = do   Just builder    <- determineDefaultBuilder (defaultBuilderConfig config)
         let runtimeConfig
              = Runtime.Config
-             { Runtime.configHeapSize = configRuntimeHeapSize config }
+             { Runtime.configHeapSize             = configRuntimeHeapSize config }
 
         let dconfig
              = Driver.Config
@@ -239,7 +239,8 @@ getDriverConfig config filePath
              , Driver.configKeepLlvmFiles         = configKeepLlvmFiles config
              , Driver.configKeepSeaFiles          = configKeepSeaFiles  config
              , Driver.configKeepAsmFiles          = configKeepAsmFiles  config 
-             , Driver.configTaintAvoidTypeChecks  = configTaintAvoidTypeChecks config }
+             , Driver.configTaintAvoidTypeChecks  = configTaintAvoidTypeChecks config
+             , Driver.configRuntimeLinkStrategy   = configRuntimeLinkStrategy config }
 
         simplLite <- getSimplLiteOfConfig config 
                         dconfig 

--- a/packages/ddc-tools/src/ddci-core/DDCI/Core/State.hs
+++ b/packages/ddc-tools/src/ddci-core/DDCI/Core/State.hs
@@ -143,6 +143,7 @@ getDriverConfigOfState state
                 = Runtime.Config
                 { Runtime.configHeapSize  = 65536 }
 
+         , D.configRuntimeLinkStrategy    = D.LinkDefault
          , D.configModuleBaseDirectories  = []
          , D.configOutputFile             = stateOutputFile state
          , D.configOutputDir              = stateOutputDir  state
@@ -176,7 +177,8 @@ getDefaultBuilderConfig
  = do   baseLibraryPath <- locateBaseLibrary
         return $ BuilderConfig
           { builderConfigBaseSrcDir     = baseLibraryPath
-          , builderConfigBaseLibDir     = baseLibraryPath </> "build" }
+          , builderConfigBaseLibDir     = baseLibraryPath </> "build"
+          , builderConfigLibFile        = \_static dynamic -> dynamic }
 
 
 -- | Get the active builder.

--- a/packages/ddc-tools/src/ddci-tetra/DDCI/Tetra/State.hs
+++ b/packages/ddc-tools/src/ddci-tetra/DDCI/Tetra/State.hs
@@ -77,6 +77,7 @@ getDriverConfigOfState state
                 = Runtime.Config
                 { Runtime.configHeapSize = 65536 }
 
+         , D.configRuntimeLinkStrategy          = D.LinkDefault
          , D.configModuleBaseDirectories        = []
          , D.configOutputFile                   = Nothing
          , D.configOutputDir                    = Nothing
@@ -109,7 +110,8 @@ getDefaultBuilderConfig
  = do   baseLibraryPath <- locateBaseLibrary
         return $ BuilderConfig
           { builderConfigBaseSrcDir             = baseLibraryPath
-          , builderConfigBaseLibDir             = baseLibraryPath </> "build" }
+          , builderConfigBaseLibDir             = baseLibraryPath </> "build"
+          , builderConfigLibFile                = \_static dynamic -> dynamic }
 
 
 -- | Get the active builder.


### PR DESCRIPTION
Enabling this option forces static linking of the runtime on supported platforms.

A binary with a statically linked runtime adds 10KB to the executable size.

The only dynamically linked library for an executable on OS X is now `/usr/lib/libSystem.B.dylib`.
