### PR TITLE
Replace gcc with cc and make assembler work for OSX

### DIFF
--- a/packages/ddc-build/DDC/Build/Builder.hs
+++ b/packages/ddc-build/DDC/Build/Builder.hs
@@ -179,8 +179,9 @@ builder_X8632_Darwin config
         , buildLlc    
                 = \llFile sFile
                 -> doCmd "LLVM compiler"        [(2, BuilderCanceled)]
-                [ "llc -O3 -march=x86 -relocation-model=pic" 
-                ,       llFile 
+                [ "opt -O3"
+                , llFile
+                , "| llc -O3 -march=x86 -relocation-model=pic"
                 , "-o", sFile ]
 
         , buildCC
@@ -232,8 +233,9 @@ builder_X8664_Darwin config
         , buildLlc    
                 = \llFile sFile
                 -> doCmd "LLVM compiler"        [(2, BuilderCanceled)]
-                [ "llc -O3 -march=x86-64 -relocation-model=pic"
-                ,       llFile 
+                [ "opt -O3"
+                , llFile
+                , "| llc -O3 -march=x86-64 -relocation-model=pic"
                 , "-o", sFile ]
 
         , buildCC


### PR DESCRIPTION
This makes the minimum llvm version 3.5 because it requires the new llvm-mc tool!
