### PR TITLE
External names

### DIFF
--- a/src/s1/ddc-core-discus/DDC/Core/Discus/Check.hs
+++ b/src/s1/ddc-core-discus/DDC/Core/Discus/Check.hs
@@ -21,7 +21,7 @@ checkModule mm
          -> Just ErrorMainMissing
 
         -- Main function exports a main function with the correct mode.
-        Just (ExportValueLocal _ tMain _)
+        Just (ExportValueLocal (ModuleName ["Main"]) (NameVar "main") tMain _)
          -> let -- .. and the type is ok.
                 check
                  | Just (t1, t2)                             <- takeTFun tMain

--- a/src/s1/ddc-core-discus/DDC/Core/Discus/Convert.hs
+++ b/src/s1/ddc-core-discus/DDC/Core/Discus/Convert.hs
@@ -219,19 +219,19 @@ convertExportValueM
 
 convertExportValueM tctx tsSalt esrc
  = case esrc of
-        ExportValueLocal n t _
+        ExportValueLocal mn n t _
          -> do  n'      <- convertBindNameM n
 
                 case Map.lookup n' tsSalt of
                  -- We have a Salt type for this exported value.
-                 Just t' -> return $ ExportValueLocal n' t' Nothing
+                 Just t' -> return $ ExportValueLocal mn n' t' Nothing
 
                  -- If a type has been foreign imported from Salt land
                  -- then it won't be in the map, and we can just convert
                  -- its Discus type to get the Salt version.
                  Nothing
                   -> do t'      <- convertSuperT tctx t
-                        return $ ExportValueLocal n' t' Nothing
+                        return $ ExportValueLocal mn n' t' Nothing
 
         ExportValueLocalNoType n
          -> do  n'      <- convertBindNameM n

--- a/src/s1/ddc-core-flow/DDC/Core/Flow/Convert.hs
+++ b/src/s1/ddc-core-flow/DDC/Core/Flow/Convert.hs
@@ -119,10 +119,10 @@ convertExportValueM
 
 convertExportValueM (_, esrc)
  = case esrc of
-        ExportValueLocal n t _
+        ExportValueLocal mn n t _
          -> do  n'      <- convertName n
                 t'      <- convertType t
-                return  $ (n', ExportValueLocal n' t' Nothing)
+                return  $ (n', ExportValueLocal mn n' t' Nothing)
 
         ExportValueLocalNoType n
          -> do  n'      <- convertName n

--- a/src/s1/ddc-core-flow/DDC/Core/Flow/Transform/Concretize.hs
+++ b/src/s1/ddc-core-flow/DDC/Core/Flow/Transform/Concretize.hs
@@ -12,7 +12,7 @@ import qualified DDC.Core.Env.EnvX      as EnvX
 import qualified Data.Map               as Map
 
 
--- | Rewrite operators that use type level rates to ones that 
+-- | Rewrite operators that use type level rates to ones that
 --   use value level ones.
 concretizeModule :: Module () Name -> Module () Name
 concretizeModule mm
@@ -20,7 +20,7 @@ concretizeModule mm
 
 
 -- | Rewrite an expression to use concrete operators.
-concretizeX 
+concretizeX
         :: EnvX Name
         -> ExpF     -> Maybe ExpF
 
@@ -41,10 +41,10 @@ concretizeX env xx
                , [XType tK, xF])   <- takeXPrimApps xx
         , Just (nS, tP, _, tA)     <- findSeriesWithRate env tK
         , xS                       <- XVar (UName nS)
-        = Just 
-        $ xLoopN 
+        = Just
+        $ xLoopN
                 tK                              -- type level rate
-                (xRateOfSeries tP tK tA xS)  -- 
+                (xRateOfSeries tP tK tA xS)  --
                 xF                              -- loop body
 
         -- newVectorR# -> newVector#
@@ -56,7 +56,7 @@ concretizeX env xx
         $ xNewVector
                 tA
                 (xNatOfRateNat tK $ xRateOfSeries tP tK tS xS)
-                
+
         | otherwise
         = Nothing
 
@@ -64,13 +64,13 @@ concretizeX env xx
 -------------------------------------------------------------------------------
 -- | Search the given environment for the name of a RateNat with the
 --   given rate parameter. We only look at named binders.
-findRateNatWithRate 
+findRateNatWithRate
         :: EnvX Name            -- ^ Type Environment.
         -> Type Name            -- ^ Rate type.
         -> Maybe Name
                                 -- ^ RateNat name
 findRateNatWithRate env tR
- = go (Map.toList (EnvX.envxMap env))
+ = go (Map.toList (EnvX.envxLocalMap env))
  where  go []           = Nothing
         go ((n, tRN) : moar)
          | isRateNatTypeOfRate tR tRN = Just n
@@ -78,8 +78,8 @@ findRateNatWithRate env tR
 
 
 -- | Check whether some type is a RateNat type of the given rate.
-isRateNatTypeOfRate 
-        :: Type Name -> Type Name 
+isRateNatTypeOfRate
+        :: Type Name -> Type Name
         -> Bool
 
 isRateNatTypeOfRate tR tRN
@@ -95,13 +95,13 @@ isRateNatTypeOfRate tR tRN
 -------------------------------------------------------------------------------
 -- | Search the given environment for the name of a series with the
 --   given result rate parameter. We only look at named binders.
-findSeriesWithRate 
+findSeriesWithRate
         :: EnvX Name             -- ^ Type Environment.
         -> Type Name            -- ^ Rate type.
         -> Maybe (Name, Type Name, Type Name, Type Name)
         -- ^ Series name, process, result rate, element type.
 findSeriesWithRate env tK
- = go (Map.toList (EnvX.envxMap env))
+ = go (Map.toList (EnvX.envxLocalMap env))
  where  go []           = Nothing
         go ((n, tS) : moar)
          = case isSeriesTypeOfRate tK tS of
@@ -112,8 +112,8 @@ findSeriesWithRate env tK
 -- | Given a rate type and a stream type, check whether the stream
 --   is of the given result rate. If it is then return the process, result rate,
 --   loop rate and element types, otherwise `Nothing`.
-isSeriesTypeOfRate 
-        :: Type Name -> Type Name 
+isSeriesTypeOfRate
+        :: Type Name -> Type Name
         -> Maybe (Type Name, Type Name, Type Name)
 
 isSeriesTypeOfRate tK tS

--- a/src/s1/ddc-core-llvm/DDC/Core/Llvm/Convert/Exp/Atom.hs
+++ b/src/s1/ddc-core-llvm/DDC/Core/Llvm/Convert/Exp/Atom.hs
@@ -288,4 +288,3 @@ addConstant ctx lit
         let vRef = Var nLit (TPointer tLit)
         return vRef
 
-

--- a/src/s1/ddc-core-llvm/DDC/Core/Llvm/Convert/Type.hs
+++ b/src/s1/ddc-core-llvm/DDC/Core/Llvm/Convert/Type.hs
@@ -144,7 +144,7 @@ importedFunctionDeclOfType pp kenv isrc mesrc nSuper tt
         (tsArgs, tResult)       <- convertSuperType pp kenv tt
         let mkParam t           = Param t []
         return  $ FunctionDecl
-                { declName              = A.sanitizeName strName
+                { declName              = strName
                 , declLinkage           = External
                 , declCallConv          = CC_Ccc
                 , declReturnType        = tResult
@@ -158,7 +158,7 @@ importedFunctionDeclOfType pp kenv isrc mesrc nSuper tt
         (tsArgs, tResult)       <- convertSuperType pp kenv tt
         let mkParam t           = Param t []
         return  $ FunctionDecl
-                { declName              = A.sanitizeName $ T.unpack strName
+                { declName              = T.unpack strName
                 , declLinkage           = External
                 , declCallConv          = CC_Ccc
                 , declReturnType        = tResult

--- a/src/s1/ddc-core-salt/DDC/Core/Salt/Convert/Init.hs
+++ b/src/s1/ddc-core-salt/DDC/Core/Salt/Convert/Init.hs
@@ -49,8 +49,8 @@ patchMainExports xx
  = case xx of
         []      -> []
         (x : xs)
-         |  (NameVar "main", ExportValueLocal n _ mArity) <- x
-         -> (NameVar "main", ExportValueLocal n posixMainType mArity) : xs
+         |  (NameVar "main", ExportValueLocal mn n _ mArity) <- x
+         -> (NameVar "main", ExportValueLocal mn n posixMainType mArity) : xs
 
          |  otherwise
          -> x : patchMainExports xs

--- a/src/s1/ddc-core/DDC/Core/Check/Judge/Module.hs
+++ b/src/s1/ddc-core/DDC/Core/Check/Judge/Module.hs
@@ -271,13 +271,20 @@ checkModuleM !config mm@ModuleCore{} !mode
 
         -- If exported names are missing types then fill them in.
         let updateExportValue e
-                | ExportValueLocalNoType n          <- e
+                -- Exported thing was foreign imported from Sea land.
+                | ExportValueLocalNoType n  <- e
                 , Just (ImportValueSea _ nExternal t) <- lookup n ntsImportValue'
                 = ExportValueSea n nExternal t
 
+                -- Exported thing was imported from another module.
                 | ExportValueLocalNoType n <- e
+                , Just (ImportValueModule mn _ t ma)  <- lookup n ntsImportValue'
+                = ExportValueLocal mn n t ma
+
+                -- Exported thing was defined in this module.
+                | ExportValueLocalNoType n  <- e
                 , Just t  <- EnvX.lookupX (UName n) envX_binds
-                = ExportValueLocal n t Nothing
+                = ExportValueLocal (moduleName mm) n t Nothing
 
                 | otherwise = e
 

--- a/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/Base.hs
+++ b/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/Base.hs
@@ -57,8 +57,8 @@ pModuleName1 = P.pTokMaybe f
 -- | Parse a qualified variable or constructor name.
 pQualName :: Pretty n => Parser n (QualName n)
 pQualName
- = do   mn      <- pModuleName
-        pTok    (KSymbol SDot)
+ = do   ms      <- P.sepEndBy1 pModuleName1 (pTok (KSymbol SDot))
+        let mn  =  ModuleName $ concat $ map (\(ModuleName ss) -> ss) ms
         n       <- pName
         return  $ QualName mn n
 

--- a/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/ExportSpec.hs
+++ b/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/ExportSpec.hs
@@ -12,7 +12,8 @@ import DDC.Core.Module
 import DDC.Type.Exp.Simple
 import DDC.Data.Pretty
 import Control.Monad
-import qualified DDC.Control.Parser        as P
+import qualified DDC.Control.Parser     as P
+import qualified Data.Text              as T
 
 
 -- An exported thing.
@@ -59,10 +60,10 @@ pExportValue
 
 pExportValue c
  = do
-        n       <- pName
+        QualName mn n <- pQualName
         pTokSP (KOp ":")
         t       <- pType c
-        return  (ExportValue n (ExportValueLocal n t Nothing))
+        return  (ExportValue n (ExportValueLocal mn n t Nothing))
 
 
 -- | Parse a foreign value export spec.
@@ -74,11 +75,13 @@ pExportForeignValue c dst
         | "c"           <- dst
         = do    n       <- pName
                 pTokSP (KOp ":")
-                k       <- pType c
+                t       <- pType c
+
+                let nTxt = renderIndent $ ppr n
 
                 -- ISSUE #327: Allow external symbol to be specified
                 --             with foreign C imports and exports.
-                return  (ExportValue n (ExportValueLocal n k Nothing))
+                return  (ExportValue n (ExportValueSea n (T.pack nTxt) t))
 
         | otherwise
         = P.unexpected "export mode for foreign value."

--- a/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/ImportSpec.hs
+++ b/src/s1/ddc-core/DDC/Core/Codec/Text/Parser/ImportSpec.hs
@@ -183,10 +183,10 @@ pImportValue
         => Context n -> Parser n (ImportSpec n)
 
 pImportValue c
- = do   n       <- pName
+ = do   QualName mn n  <- pQualName
         pTokSP (KOp ":")
         t       <- pType c
-        return  $ ImportForeignValue n (ImportValueModule (ModuleName []) n t Nothing)
+        return  $ ImportForeignValue n (ImportValueModule mn n t Nothing)
 
 
 -- | Parse a foreign value import spec.

--- a/src/s1/ddc-core/DDC/Core/Exp/Annot/Ctx.hs
+++ b/src/s1/ddc-core/DDC/Core/Exp/Annot/Ctx.hs
@@ -19,7 +19,7 @@ import qualified Data.Map.Strict        as Map
 -- | A one-hole context for `Exp`.
 data Ctx a n
         -- | The top-level context.
-        = CtxTop        
+        = CtxTop
         { ctxEnvX       :: !(EnvX n) }
 
         -- | Body of a type abstraction.
@@ -150,17 +150,17 @@ takeTopLetEnvNamesOfCtx ctx0
          = case ctx of
                 CtxTop env
                  -> Set.fromList
-                 $  Map.keys $ EnvX.envxMap env
+                 $  Map.keys $ EnvX.envxLocalMap env
 
                 CtxLetLLet (CtxTop env) _ b xBody
                  -> Set.unions
-                        [ Set.fromList $ Map.keys $ EnvX.envxMap env
+                        [ Set.fromList $ Map.keys $ EnvX.envxLocalMap env
                         , eatBind b
                         , eatExp xBody]
 
                 CtxLetLRec (CtxTop env) _ bxsBefore b bxsAfter xBody
                  -> Set.unions
-                        [ Set.fromList  $ Map.keys $ EnvX.envxMap env
+                        [ Set.fromList  $ Map.keys $ EnvX.envxLocalMap env
                         , Set.unions    $ map (eatBind . fst) bxsBefore
                         , eatBind b
                         , Set.unions    $ map (eatBind . fst) bxsAfter

--- a/src/s1/ddc-core/DDC/Core/Module.hs
+++ b/src/s1/ddc-core/DDC/Core/Module.hs
@@ -272,7 +272,7 @@ moduleEnvX kenvPrim tenvPrim dataDefs mm
                 (DataDef.fromListDataDefs $ map snd $ moduleImportDataDefs mm)
                 (DataDef.fromListDataDefs $ map snd $ moduleLocalDataDefs  mm)
 
- , EnvX.envxMap
+ , EnvX.envxLocalMap
         = Map.fromList
                 [ (n, typeOfImportValue isrc)
                 | (n, isrc) <- moduleImportValues mm ]

--- a/src/s1/ddc-core/DDC/Core/Transform/Boxing.hs
+++ b/src/s1/ddc-core/DDC/Core/Transform/Boxing.hs
@@ -88,9 +88,9 @@ boxingModule config mm
         nsImportSea   = [ n | (n, ImportValueSea{}) <- moduleImportValues mm]
         boxingExport expt
          = case expt of
-                ExportValueLocal n t mArity
+                ExportValueLocal mn n t mArity
                   |  elem n nsImportSea
-                  -> ExportValueLocal n (boxingForeignSeaType config t) mArity
+                  -> ExportValueLocal mn n (boxingForeignSeaType config t) mArity
                 _ -> expt
 
    in   mm { moduleBody

--- a/src/s1/ddc-core/DDC/Core/Transform/Expose.hs
+++ b/src/s1/ddc-core/DDC/Core/Transform/Expose.hs
@@ -38,9 +38,9 @@ exposeModule mm
         -- Attach arity information to an export record.
         attachExportArity (n', ex)
          = case ex of
-                ExportValueLocal n t Nothing
+                ExportValueLocal mn n t Nothing
                  -> case Map.lookup n nsLocalArities of
-                     Just as -> (n', ExportValueLocal n t (Just as))
+                     Just as -> (n', ExportValueLocal mn n t (Just as))
                      Nothing -> (n', ex)
 
                 _ -> (n', ex)

--- a/src/s1/ddc-core/DDC/Core/Transform/SpreadX.hs
+++ b/src/s1/ddc-core/DDC/Core/Transform/SpreadX.hs
@@ -87,8 +87,8 @@ spreadExportTypeT kenv esrc
 ---------------------------------------------------------------------------------------------------
 spreadExportValueT kenv esrc
   = case esrc of
-        ExportValueLocal n t mArity
-         -> ExportValueLocal n (spreadT kenv t) mArity
+        ExportValueLocal mn n t mArity
+         -> ExportValueLocal mn n (spreadT kenv t) mArity
 
         ExportValueLocalNoType n
          -> ExportValueLocalNoType n

--- a/src/s1/ddc-core/DDC/Core/Transform/Unshare.hs
+++ b/src/s1/ddc-core/DDC/Core/Transform/Unshare.hs
@@ -323,10 +323,10 @@ updateExportValue
 
 updateExportValue mm ex
  = case ex of
-        ExportValueLocal n _t mArity
+        ExportValueLocal mn n _t mArity
          -> case Map.lookup n mm of
                 Nothing -> ex
-                Just t' -> ExportValueLocal n t' mArity
+                Just t' -> ExportValueLocal mn n t' mArity
 
         ExportValueLocalNoType{} -> ex
         ExportValueSea{}         -> ex

--- a/src/s1/ddc-source-discus/DDC/Source/Discus/Pretty.hs
+++ b/src/s1/ddc-source-discus/DDC/Source/Discus/Pretty.hs
@@ -134,7 +134,7 @@ instance PrettyLanguage l => Pretty (Module l) where
         sImportedValues
          | null importedValues  = empty
          | otherwise
-         = (vcat $ map pprImportValue importedValues)
+         = (vcat $ map (pprImportValue . snd) importedValues)
          <> line
 
 

--- a/src/s2/ddc-runtime/salt/runtime/Alloc.dcs
+++ b/src/s2/ddc-runtime/salt/runtime/Alloc.dcs
@@ -2,22 +2,22 @@
 -- | The Allocation System
 module Alloc
 
-export value
+export foreign c value
   -- | Garbage Collect the current heap and possibly resize it so that
-  --   we have at least the given amount of free space available 
+  --   we have at least the given amount of free space available
   --   for allocation.
-  ddcAllocCollect       
+  ddcAllocCollect
         :  Nat# -- ^ How much space must be left after collection.
         -> Unit
 
 import foreign c value
-  ddcCollectHeap        
+  ddcCollectHeap
         :  Addr#
         -> Addr# -> Addr# -> Addr#
         -> Addr# -> Addr# -> Addr#
         -> Unit
 
-  ddcLlvmRootGetStart   
+  ddcLlvmRootGetStart
          : Nat#  -> Addr#
 
   free   : Addr# -> Void#
@@ -35,7 +35,7 @@ ddcAllocCollect (byteCount : Nat#) : Unit
         --   This copies live objects from the front heap to the back heap
         --   then flips the heap. Once it's done the live objects are in the
         --   front heap.
-        ddcCollectHeap  
+        ddcCollectHeap
                 (ddcLlvmRootGetStart 0#)
                 (global# [Addr#] "ddcHeapBase"#)
                 (global# [Addr#] "ddcHeapTop"#)
@@ -50,39 +50,39 @@ ddcAllocCollect (byteCount : Nat#) : Unit
         aNewMax         = read# [Addr#] (global# [Addr#] "ddcHeapMax"#) 0#
 
         case gt# (plusAddr# aNewTop byteCount) aNewMax of
-         -- If there isn't enough space in the collected heap then we 
+         -- If there isn't enough space in the collected heap then we
          -- allocate some more space from the operating system.
          --
          -- Once we've done this we need to call the collector again to
          -- copy the live objects into this newly allocated space.
-         -- We can't just 'memcpy' because we also need to adjust all the 
+         -- We can't just 'memcpy' because we also need to adjust all the
          -- internal pointers to reflect that fact that we've moved the
          -- objects.
          --
-         True#  
+         True#
           ->    ddcAllocResize  byteCount
 
-         False# 
+         False#
           ->    ()
 
 
 -- | Given that we've just performed a GC cycle and don't have enough space
 --   to perform the next allocation, grow the heap by requesting more space
 --   from the OS so that the next allocation will be possible.
-ddcAllocResize 
+ddcAllocResize
         (minAlloc: Nat#)        -- Minimum extra space needed above what
                                 -- we've already got.
         : Unit
- = do   
+ = do
         aCurBase        = read# [Addr#] (global# [Addr#] "ddcHeapBase"#) 0#
         aCurTop         = read# [Addr#] (global# [Addr#] "ddcHeapTop"#)  0#
         aCurMax         = read# [Addr#] (global# [Addr#] "ddcHeapMax"#)  0#
-               
+
         -- Current size of the heap.
         curSize         = add# 1# (truncate# [Nat#] (sub# aCurMax aCurBase))
 
         -- Current usage of the heap.
-        --   When we call ddcAllocResize we've just collected the heap, 
+        --   When we call ddcAllocResize we've just collected the heap,
         --   so this is the exact amount of live data.
         curUsage        = truncate# [Nat#] (sub# aCurTop aCurBase)
 
@@ -104,13 +104,13 @@ ddcAllocResize
         aHeapBackBase1_new      = malloc newSize
         write#  (global# [Addr#] "ddcHeapBackBase"#) 0# aHeapBackBase1_new
         write#  (global# [Addr#] "ddcHeapBackTop"#)  0# aHeapBackBase1_new
-        write#  (global# [Addr#] "ddcHeapBackMax"#)  0# 
+        write#  (global# [Addr#] "ddcHeapBackMax"#)  0#
                 (plusAddr# aHeapBackBase1_new (sub# newSize 1#))
 
         -- Run the collector again to copy live objects into the new back buffer.
         --   This also flips the buffers, so after the collection our freshly
         --   allocated buffer is now the one reachable from the front pointers.
-        ddcCollectHeap  
+        ddcCollectHeap
                 (ddcLlvmRootGetStart 0#)
                 (global# [Addr#] "ddcHeapBase"#)
                 (global# [Addr#] "ddcHeapTop"#)

--- a/src/s2/ddc-runtime/salt/runtime/Collect.dcs
+++ b/src/s2/ddc-runtime/salt/runtime/Collect.dcs
@@ -2,7 +2,7 @@
 -- | The Garbage Collector
 module Collect
 
-export value
+export foreign c value
 
   -- | Garbage Collect the current heap.
   ddcPerformGC

--- a/src/s2/ddc-runtime/salt/runtime/Init.dcs
+++ b/src/s2/ddc-runtime/salt/runtime/Init.dcs
@@ -1,18 +1,19 @@
 
 -- Initialization functions for the runtime system.
 --
---   This module is treated specially by the LLVM code generator. 
+--   This module is treated specially by the LLVM code generator.
 --
 --   When compiling this module the global symbols used by the runtime
 --   system are declared statically, and exported with external linkage.
 --   For all other modules the symbols are imported.
 --
 --   This module must contain uses of those global symbols, otherwise
---   the system linker will forget about the symbols when building 
+--   the system linker will forget about the symbols when building
 --   the runtime system .dylib library.
 --
 module Init
-export value
+
+export foreign c value
  ddcInit        :  Nat# -> Nat# -> Addr# -> Unit
  ddcExit        :  Nat# -> Void#
 
@@ -30,7 +31,7 @@ ddcInit (defaultHeapSize: Nat#) -- Default heap size set at compile time.
         (argc: Nat#)            -- Number of command line arguments.
         (argv: Addr#)           -- Pointer to array of command line arguments.
         : Unit
- = do   
+ = do
         ddcAllocInit   defaultHeapSize
         write# (global# [Nat#]  "ddcEnvArgC"#)      0# argc
         write# (global# [Addr#] "ddcEnvArgV"#)      0# argv
@@ -44,7 +45,7 @@ ddcAllocInit (heapSize : Nat#) : Unit
         pHeapBaseA      = malloc heapSize
         write# (global# [Addr#] "ddcHeapBase"#)     0# pHeapBaseA
         write# (global# [Addr#] "ddcHeapTop"#)      0# pHeapBaseA
-        write# (global# [Addr#] "ddcHeapMax"#)      0# 
+        write# (global# [Addr#] "ddcHeapMax"#)      0#
                (plusAddr# pHeapBaseA    (sub# heapSize 1#))
 
         -- Create the back heap.
@@ -60,7 +61,7 @@ ddcAllocInit (heapSize : Nat#) : Unit
 -------------------------------------------------------------------------------
 -- | Shutdown the runtime system and exit cleanly.
 ddcExit (code: Nat#): Void#
- = do   
+ = do
         -- Free the space for the heaps.
         pHeapBaseA      = read# (global# [Addr#] "ddcHeapBase"#)     0#
         pHeapBackBaseA  = read# (global# [Addr#] "ddcHeapBackBase"#) 0#

--- a/src/s2/ddc-runtime/salt/runtime64/Apply.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/Apply.dcs
@@ -2,7 +2,7 @@
  -- Thunk application.
 module Runtime.Apply
 
-export value
+export foreign c value
  ddcRunThunk    :  [r1 : Region]. Ptr# r1 Obj -> Ptr# r1 Obj
 
  ddcApply0      :  [r1 : Region]
@@ -22,7 +22,7 @@ export value
                 .  Ptr# r1 Obj -> Ptr# r1 Obj -> Ptr# r1 Obj -> Ptr# r1 Obj
                 -> Ptr# r1 Obj -> Ptr# r1 Obj
 
-import value
+import foreign c value
  ddcAllocThunk  : [r1 : Region]. Addr# -> Nat# -> Nat# -> Nat# -> Nat# -> Ptr# r1 Obj
  ddcCopyThunk   : [r1 : Region]. Ptr# r1 Obj -> Ptr# r1 Obj -> Nat# -> Nat# -> Ptr# r1 Obj
  ddcExtendThunk : [r1 : Region]. Ptr# r1 Obj -> Nat# -> Ptr# r1 Obj

--- a/src/s2/ddc-runtime/salt/runtime64/Object.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/Object.dcs
@@ -79,7 +79,7 @@
 --
 module Runtime.Object
 
-export value
+export foreign c value
  -- Get the tag of an object.
  ddcTagOfObject         : [r: Region]. Ptr# r Obj  -> Tag#
  ddcFormatOfObject      : [r: Region]. Ptr# r Obj  -> Nat#
@@ -121,7 +121,7 @@ export value
  ddcPayloadSmall     : [r1:    Region]. Ptr# r1 Obj  -> Ptr# r1 Word8#
  ddcPayloadSizeSmall : [r1:    Region]. Ptr# r1 Obj  -> Nat#
 
-import value
+import foreign c value
  -- Invoke the garbage collector.
  -- We need to relaim at least the given number of bytes,
  -- otherwise we cannot continue execution.

--- a/src/s2/ddc-runtime/salt/runtime64/debug/Check.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/debug/Check.dcs
@@ -1,13 +1,13 @@
 
 module Check
 
-export value
+export foreign c value
  ddcCheckObjHeader : [r: Region]. Ptr# r Obj -> Word32#
  ddcCheckObjExtent : [r: Region]. Ptr# r Obj -> Nat# -> Unit
  ddcFailMessage    : TextLit# -> TextLit# -> Void#
  ddcFailField      : TextLit# -> TextLit# -> Void#
 
-import value
+import foreign c value
  ddcPrimShowAddr   : Addr#    -> TextLit#
  ddcPrimShowNat    : Nat#     -> TextLit#
  ddcPrimFailString : TextLit# -> Void#

--- a/src/s2/ddc-runtime/salt/runtime64/debug/Trace.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/debug/Trace.dcs
@@ -2,7 +2,7 @@
 -- | Dumping of the runtime object graph.
 module Trace
 
-export value
+export foreign c value
 
  ddcTraceAlloc
         :  Bool# -> Addr#
@@ -14,7 +14,8 @@ export value
  ddcTraceRoots          : Bool# -> Unit
  ddcTraceHeap           : Bool# -> Unit
 
-import value
+
+import foreign c value
  -- Primitives imported from C-land.
  ddcPrimStdoutPutString : TextLit# -> Void#
  ddcPrimFailString      : TextLit# -> Void#

--- a/src/s2/ddc-runtime/salt/runtime64/primitive/Array.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/primitive/Array.dcs
@@ -1,13 +1,14 @@
 
 -- | Arrays of pointers to boxed values.
 module Runtime.Prim.Array
-export value
+
+export foreign c value
  allocStoreArray : [r1 r2 : Region]. Nat# -> Ptr# r1 Obj -> Ptr# r2 Obj
  writeStoreArray : [r1 r2 : Region]. Ptr# r1 Obj -> Nat# -> Ptr# r2 Obj -> Ptr# r1 Obj
  readStoreArray  : [r1 r2 : Region]. Ptr# r1 Obj -> Nat# -> Ptr# r2 Obj
  fillStoreArray  : [r1 r2 : Region]. Ptr# r1 Obj -> Nat# -> Nat# -> Ptr# r2 Obj -> Ptr# r1 Obj
 
-import value
+import foreign c value
  ddcAllocBoxed   : [r1    : Region]. Tag# -> Nat# -> Ptr# r1 Obj
  ddcSetBoxed     : [r1 r2 : Region]. Ptr# r1 Obj  -> Nat# -> Ptr# r2 Obj -> Void#
 
@@ -16,10 +17,10 @@ with letrec
 
 -- | Allocate an array of boxed values, consisting of the same element
 --   for all positions.
-allocStoreArray 
+allocStoreArray
         [r1 r2: Region]
         (len: Nat#) (pVal: Ptr# r1 Obj): Ptr# r2 Obj
- = do   
+ = do
         sVal    = allocSlot# [r1]
 
         poke# sVal pVal
@@ -31,10 +32,10 @@ allocStoreArray
 
 
 -- | Write an element into an array.
-writeStoreArray 
-        [r1 r2: Region] 
+writeStoreArray
+        [r1 r2: Region]
         (obj: Ptr# r1 Obj) (ix: Nat#) (val: Ptr# r2 Obj): Ptr# r1 Obj
- = do   
+ = do
         -- Get address of the first byte after the end of the array.
         len     = promote# (peek# [r1] [Word32#] (plusPtr# (castPtr# obj) 4#))
         top     = add# 8#  (shl# len (size2# [Addr#]))
@@ -47,10 +48,10 @@ writeStoreArray
 
 
 -- | Read an element from an array.
-readStoreArray 
+readStoreArray
         [r1 r2: Region]
         (obj: Ptr# r1 Obj) (ix: Nat#): Ptr# r2 Obj
- = do   
+ = do
         -- Get address of the first byte after the end of the array.
         len     = promote# (peek# [r1] [Word32#] (plusPtr# (castPtr# obj) 4#) )
         top     = add# 8#  (shl#  len  (size2# [Addr#]))

--- a/src/s2/ddc-runtime/salt/runtime64/primitive/Env.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/primitive/Env.dcs
@@ -1,6 +1,7 @@
 
 module Env
-export value 
+
+export foreign c value
  ddcEnvGetArgC     : Nat# -> Nat#
  ddcEnvGetArgV     : Nat# -> Addr#
 

--- a/src/s2/ddc-runtime/salt/runtime64/primitive/Ref.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/primitive/Ref.dcs
@@ -1,12 +1,13 @@
 
 -- | References to boxed values.
 module Runtime.Prim.Ref
-export value
+
+export foreign c value
  ddcPrimRefAlloc  : [r1 r2 : Region]. Ptr# r1 Obj -> Ptr# r2 Obj
  ddcPrimRefRead   : [r1 r2 : Region]. Ptr# r1 Obj -> Ptr# r2 Obj
  ddcPrimRefWrite  : [r1 r2 : Region]. Ptr# r1 Obj -> Ptr# r2 Obj -> Void#
 
-import value
+import foreign c value
  ddcAllocBoxed    : [r1    : Region]. Tag# -> Nat# -> Ptr# r1 Obj
  ddcGetBoxed      : [r1 r2 : Region]. Ptr# r1 Obj  -> Nat# -> Ptr# r2 Obj
  ddcSetBoxed      : [r1 r2 : Region]. Ptr# r1 Obj  -> Nat# -> Ptr# r2 Obj -> Void#

--- a/src/s2/ddc-runtime/salt/runtime64/primitive/Text.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/primitive/Text.dcs
@@ -1,17 +1,17 @@
 
 module Runtime.Prim.Text
-export value
+
+export foreign c value
  ddcPrimMakeTextLit     : [r1: Region]. Addr# -> Ptr# r1 Obj
  ddcPrimTakeTextLit     : [r1: Region]. Ptr# r1 Obj -> Addr#
  ddcPrimSizeOfTextLit   : [r1: Region]. Ptr# r1 Obj -> Nat#
  ddcPrimIndexTextLit    : [r1: Region]. Ptr# r1 Obj -> Nat# -> Word8#
 
-import value
+import foreign c value
  -- Objects with raw, non-pointer data.
  ddcAllocRaw            : [r1: Region]. Tag# -> Nat# -> Ptr# r1 Obj
  ddcPayloadRaw          : [r1: Region]. Ptr# r1 Obj  -> Ptr# r1 Word8#
  ddcPayloadSizeRaw      : [r1: Region]. Ptr# r1 Obj  -> Nat#
-
  ddcPrimPutString       : TextLit# -> Void#
 
 with letrec

--- a/src/s2/ddc-runtime/salt/runtime64/primitive/Vector.dcs
+++ b/src/s2/ddc-runtime/salt/runtime64/primitive/Vector.dcs
@@ -1,12 +1,11 @@
 
 module Runtime.Prim.Vector
 
-export value
+export foreign c value
  ddcVectorGuts : [r : Region]. Ptr# r Obj -> Addr#
 
-import value
+import foreign c value
  ddcPayloadRaw : [r : Region]. Ptr# r Obj -> Ptr# r Word8#
-
 
 with letrec
 

--- a/test/ddc-demo/core/Discus/00-Hello/Main.dct
+++ b/test/ddc-demo/core/Discus/00-Hello/Main.dct
@@ -4,7 +4,8 @@
 module Main
 
 -- Export the main entry point to C land.
-export main : Unit -> S Console Unit
+export value
+ Main.main : Unit -> S Console Unit
 
 -- Define the console effect, which is the one we'll use to
 -- classify actions that write to the console.

--- a/test/ddc-demo/core/Discus/01-Factorial/Main.dct
+++ b/test/ddc-demo/core/Discus/01-Factorial/Main.dct
@@ -3,7 +3,8 @@
 module Main
 
 -- Export the main entry point to C land.
-export main : Unit -> S Console Unit
+export value
+ Main.main : Unit -> S Console Unit
 
 -- Define the console effect, which is the one we'll use to
 -- classify actions that write to the console.

--- a/test/ddc-demo/core/Discus/02-Lists/Main.dct
+++ b/test/ddc-demo/core/Discus/02-Lists/Main.dct
@@ -3,7 +3,8 @@
 module Main
 
 -- Export the main entry point to C land.
-export main : Unit -> S Console Unit
+export value
+ Main.main : Unit -> S Console Unit
 
 -- Define the console effect, which is the one we'll use to
 -- classify actions that write to the console.

--- a/test/ddc-demo/core/Salt/00-Hello/Main.dcs
+++ b/test/ddc-demo/core/Salt/00-Hello/Main.dcs
@@ -5,7 +5,8 @@
 module Main
 
 -- Export the main entry point.
-export main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
+export foreign c value
+        main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
 
 -- Primitive show functions are defined in the runtime system.
 import foreign c value

--- a/test/ddc-demo/core/Salt/01-Factorial/Main.dcs
+++ b/test/ddc-demo/core/Salt/01-Factorial/Main.dcs
@@ -3,7 +3,8 @@
 module Main
 
 -- Export the main entry point.
-export main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
+export foreign c value
+        main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
 
 import foreign abstract type
         RegionText      : Region

--- a/test/ddc-demo/core/Salt/02-Boxing/Main.dcs
+++ b/test/ddc-demo/core/Salt/02-Boxing/Main.dcs
@@ -5,7 +5,9 @@
 -- boxed arithmetic.
 --
 module Main
-export main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
+
+export foreign c value
+        main  : [r1: Region]. Nat# -> Ptr# r1 Word8# -> Int#
 
 -- Primitive show functions are defined in the runtime system.
 import foreign c value

--- a/test/ddc-regress/core/02-Salt/40-Standalone/40-Factorial/Main.dcs
+++ b/test/ddc-regress/core/02-Salt/40-Standalone/40-Factorial/Main.dcs
@@ -1,7 +1,7 @@
 
 module Main
 export {
-        main      : [r1 r2 : Region]. Nat# -> Ptr# r1 (Ptr# r1 Word8#) -> Int#;
+        Main.main      : [r1 r2 : Region]. Nat# -> Ptr# r1 (Ptr# r1 Word8#) -> Int#;
 }
 import foreign c value {
         ddcInit                : Nat# -> Nat# -> Unit;

--- a/test/ddc-regress/core/02-Salt/40-Standalone/41-Normalise/Main.dcs
+++ b/test/ddc-regress/core/02-Salt/40-Standalone/41-Normalise/Main.dcs
@@ -1,7 +1,7 @@
 
 module Main
 export {
-         main     : [r1 : Region]. Nat# -> Ptr# r1 (Ptr# r1 Word8#) -> Int#;
+        Main.main     : [r1 : Region]. Nat# -> Ptr# r1 (Ptr# r1 Word8#) -> Int#;
 }
 import foreign c value {
         ddcInit                 : Nat# -> Nat# -> Unit;

--- a/test/ddc-regress/core/03-Discus/10-Syntax/40-Module/Test.dcx
+++ b/test/ddc-regress/core/03-Discus/10-Syntax/40-Module/Test.dcx
@@ -4,11 +4,11 @@
 :load..
 module Main
 export value {
-        main    : Unit -> S Pure Unit;
-        double  : Nat# -> Nat#;
+        Main.main    : Unit -> S Pure Unit;
+        Main.double  : Nat# -> Nat#;
 }
 import value {
-        two : Unit -> Nat#;
+        Main.two : Unit -> Nat#;
 }
 with
 private rt with { w1 : Const rt } in
@@ -30,10 +30,10 @@ letrec {
 :load..
 module  Main
 export value
-        main    : Unit -> S Pure Unit
-        double  : Nat# -> Nat#
+        Main.main    : Unit -> S Pure Unit
+        Main.double  : Nat# -> Nat#
 import value
-        two : Unit -> Nat#
+        Main.two : Unit -> Nat#
 with
 private rt with { w1 : Const rt } in
 let     one = 1# in

--- a/test/ddc-regress/core/03-Discus/10-Syntax/40-Module/Test.stdout.check
+++ b/test/ddc-regress/core/03-Discus/10-Syntax/40-Module/Test.stdout.check
@@ -1,10 +1,10 @@
 ok
 
 -- Load a module definition.
-module Main
-export value main       : Unit -> S Pure Unit;
-export value double     : Nat# -> Nat#;
-import value two        : Unit -> Nat#;
+module Main 
+export value Main.main : Unit -> S Pure Unit;
+export value Main.double: Nat# -> Nat#;
+import value Main.two   : Unit -> Nat#;
 with
 private rt with {w1: Const rt}
 let one: Nat#
@@ -27,10 +27,10 @@ letrec {
 
 
 -- Load the same module using the offside rule.
-module Main
-export value main       : Unit -> S Pure Unit;
-export value double     : Nat# -> Nat#;
-import value two        : Unit -> Nat#;
+module Main 
+export value Main.main : Unit -> S Pure Unit;
+export value Main.double: Nat# -> Nat#;
+import value Main.two   : Unit -> Nat#;
 with
 private rt with {w1: Const rt}
 let one: Nat#

--- a/test/ddc-regress/core/03-Discus/11-Parser/T289-UnmatchedBraces/Main.dct
+++ b/test/ddc-regress/core/03-Discus/11-Parser/T289-UnmatchedBraces/Main.dct
@@ -2,11 +2,11 @@
 -- This module contains an extra misplaced close brace
 -- which the offside rule code needs to give a sensible error for.
 --
--- The point here is that the offside rule inserts a synthetic open 
+-- The point here is that the offside rule inserts a synthetic open
 -- brace after the 'do' but there is a manifest user-written one after it.
 
-module Main 
-export  main    : [r : Region]. Nat# -> Ptr# r Word8# -> Int#;
+module Main
+export  Main.main    : [r : Region]. Nat# -> Ptr# r Word8# -> Int#;
 with letrec
 
 main    [e: Effect] : Unit -> S e Unit

--- a/test/ddc-regress/core/03-Discus/22-Typing/03-LetRegion/Test.dcx
+++ b/test/ddc-regress/core/03-Discus/22-Typing/03-LetRegion/Test.dcx
@@ -35,7 +35,7 @@ module Test
 import data Ref (r : Region) (a : Data) where {
         MkRef : a -> Ref r a
 }
-import value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
+import foreign c value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
 with letrec
 test : Nat#
  = private r1 with { w1 : Const r1 } in
@@ -45,14 +45,14 @@ test : Nat#
 ;;
 
 
--- Error: private region variable cannot shadow variable that is already 
+-- Error: private region variable cannot shadow variable that is already
 -- in the environment.
 :load..
 module Test
 import data Ref (r : Region) (a : Data) where {
         MkRef : a -> Ref r a
 }
-import value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
+import foreign c value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
 with letrec
 test [r : Region] (x : Ref r Nat#) : S (Write r) Unit
  = private r with { w1 : Mutable r } in
@@ -67,11 +67,11 @@ module Test
 import data Ref (r : Region) (a : Data) where {
         MkRef : a -> Ref r a
 }
-import value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
+import foreign c value writeRef : [r : Region]. [a : Data]. Ref r a -> a -> S (Write r) Unit
 with letrec
 test : Unit
  = do   private r in MkRef [r] [Nat#] 5#
-        () 
+        ()
 ;;
 
 

--- a/test/ddc-regress/core/03-Discus/22-Typing/40-Module/Test.dcx
+++ b/test/ddc-regress/core/03-Discus/22-Typing/40-Module/Test.dcx
@@ -3,8 +3,8 @@
 
 -- Main module exports main function of the correct type.
 :load..
-module Main 
-export main : Unit -> S Pure Unit
+module Main
+export Main.main : Unit -> S Pure Unit
 with letrec
 main (x : Unit) : S Pure Unit
  = box ()
@@ -13,8 +13,8 @@ main (x : Unit) : S Pure Unit
 
 -- Error: No main function.
 :load..
-module Main 
-export blerk : Unit -> S Pure Unit
+module Main
+export Main.blerk : Unit -> S Pure Unit
 with letrec
 blerk (x : Unit) : S Pure Unit
  = box ()
@@ -23,8 +23,8 @@ blerk (x : Unit) : S Pure Unit
 
 -- Error: Main function has invalid type.
 :load..
-module Main 
-export main : Nat# -> Nat# -> S Pure Unit
+module Main
+export Main.main : Nat# -> Nat# -> S Pure Unit
 with letrec
 main (x y : Nat#) : S Pure Unit
  = box ()
@@ -34,9 +34,9 @@ main (x y : Nat#) : S Pure Unit
 -- Error: duplicate export of name.
 -- #295: Check for duplicate exported names in module parser.
 :load..
-module Main 
-export main : Unit -> S Pure Unit
-export main : Unit -> S Pure Unit
+module Main
+export Main.main : Unit -> S Pure Unit
+export Main.main : Unit -> S Pure Unit
 with letrec
 main (x : Unit) : S Pure Unit
  = box ()

--- a/test/ddc-regress/core/03-Discus/22-Typing/40-Module/Test.stdout.check
+++ b/test/ddc-regress/core/03-Discus/22-Typing/40-Module/Test.stdout.check
@@ -2,8 +2,8 @@ ok
 
 
 -- Main module exports main function of the correct type.
-module Main
-export value main       : Unit -> S Pure Unit;
+module Main 
+export value Main.main : Unit -> S Pure Unit;
 with
 letrec {
   main: Unit -> S Pure Unit

--- a/test/ddc-regress/core/03-Discus/22-Typing/T253-RedefinedTopBind/Main.dct
+++ b/test/ddc-regress/core/03-Discus/22-Typing/T253-RedefinedTopBind/Main.dct
@@ -1,6 +1,6 @@
 
 module Main
-export main      : [e: Effect]. Unit -> S e Unit
+export Main.main  : [e: Effect]. Unit -> S e Unit
 with letrec
 
 main [e: Effect] (u: Unit): Unit

--- a/test/ddc-regress/core/04-Flow/20-Prep/20-Eta/Test.dcx
+++ b/test/ddc-regress/core/04-Flow/20-Prep/20-Eta/Test.dcx
@@ -3,8 +3,8 @@
 :set lang Flow
 :set trans Eta
 :load..
-module Test 
-import value f : Int# -> Int# -> Int#
+module Test
+import value Foo.f : Int# -> Int# -> Int#
 with letrec
 ffold [p : Proc] [k : Rate]
     (o : Ref# Int#)

--- a/test/ddc-regress/core/04-Flow/20-Prep/20-Eta/Test.stdout.check
+++ b/test/ddc-regress/core/04-Flow/20-Prep/20-Eta/Test.stdout.check
@@ -3,7 +3,7 @@
 ok
 ok
 module Test 
-import value f          : Int# -> Int# -> Int#;
+import value Foo.f      : Int# -> Int# -> Int#;
 with
 letrec {
   ffold: [p: Proc].[k: Rate].Ref# Int# -> Series# p k Int# -> Process# p k

--- a/test/ddc-regress/core/04-Flow/50-Wind/Test.dcx
+++ b/test/ddc-regress/core/04-Flow/50-Wind/Test.dcx
@@ -28,7 +28,7 @@ lower_map_map_rq2 : [p : Proc]. [k_d : Rate].Series# p k_d Int# -> Vector# Int#
 :flow-wind..
 module Main
 import value {
-        maxx : Int# -> Int# -> Int#;
+        Base.maxx : Int# -> Int# -> Int#;
 } with
 letrec {
 filterMax : [p : Proc]. [k : Rate].Series# p k Int# -> Tuple2# (Vector# Int#) Int#
@@ -57,7 +57,7 @@ filterMax : [p : Proc]. [k : Rate].Series# p k Int# -> Tuple2# (Vector# Int#) In
                 ()) in
    let x4  : Nat#         = read# k2__count in
    let _   : Unit         = vtrunc# x4 x5 in
-   let x9  : Int#         = read# x9__acc 
+   let x9  : Int#         = read# x9__acc
    in T2# x5 x9
 }
 ;;
@@ -67,8 +67,8 @@ filterMax : [p : Proc]. [k : Rate].Series# p k Int# -> Tuple2# (Vector# Int#) In
 :flow-wind..
 module Test with
 letrec {
-  test : [p : Proc]. [k : Rate].RateNat# k 
-        -> Ref# Float32# -> Ref# Float32# 
+  test : [p : Proc]. [k : Rate].RateNat# k
+        -> Ref# Float32# -> Ref# Float32#
         -> Series# p k Float32# -> Series# p k Float32# -> Unit
     = /\(p : Proc).
       /\(k : Rate).

--- a/test/ddc-regress/core/04-Flow/50-Wind/Test.stdout.check
+++ b/test/ddc-regress/core/04-Flow/50-Wind/Test.stdout.check
@@ -40,7 +40,7 @@ letrec {
 
 -- Loop with a guard and a scalar result.
 module Main 
-import value maxx       : Int# -> Int# -> Int#;
+import value Base.maxx  : Int# -> Int# -> Int#;
 with
 letrec {
   filterMax: [p: Proc].[k: Rate].Series# p k Int# -> Tuple2# (Vector# Int#) Int#

--- a/test/ddc-regress/core/04-Flow/60-Melt/Test.dcx
+++ b/test/ddc-regress/core/04-Flow/60-Melt/Test.dcx
@@ -1,9 +1,9 @@
 
 :flow-melt..
-module Test 
+module Test
 import value {
-        addInt : Int# -> Int# -> Int#;
-        minIx  : Nat# -> Tuple2# Int# Int# -> Int# -> Tuple2# Int# Int#;
+        Base.addInt : Int# -> Int# -> Int#;
+        Base.minIx  : Nat# -> Tuple2# Int# Int# -> Int# -> Tuple2# Int# Int#;
 } with
 letrec {
   foldix : [p : Proc]. [k : Rate].Series# p k Int# -> Tuple2# (Tuple2# Int# Int#) Int#

--- a/test/ddc-regress/core/04-Flow/60-Melt/Test.stdout.check
+++ b/test/ddc-regress/core/04-Flow/60-Melt/Test.stdout.check
@@ -1,7 +1,7 @@
 
 module Test 
-import value addInt     : Int# -> Int# -> Int#;
-import value minIx      : Nat# -> Tuple2# Int# Int# -> Int# -> Tuple2# Int# Int#;
+import value Base.addInt : Int# -> Int# -> Int#;
+import value Base.minIx : Nat# -> Tuple2# Int# Int# -> Int# -> Tuple2# Int# Int#;
 with
 letrec {
   foldix: [p: Proc].[k: Rate].Series# p k Int# -> Tuple2# (Tuple2# Int# Int#) Int#

--- a/test/ddc-regress/core/05-Machine/10-Prep/Test.dcx
+++ b/test/ddc-regress/core/05-Machine/10-Prep/Test.dcx
@@ -12,12 +12,14 @@ import foreign abstract type
     a0 : Data
     b0 : Data
     c0 : Data
+
 import value
-    f0 : a0 -> b0
-    g0 : b0 -> c0
+    Base.f0 : a0 -> b0
+    Base.g0 : b0 -> c0
 
 -- Mark the top-level function as an export so it won't be forwarded
-export exec : Source# a0 -> Sink# c0 -> Process#
+export value
+    Main.exec : Source# a0 -> Sink# c0 -> Process#
 
 with
 -- These need to be lets, not letrec because Forward (rightly) doesn't

--- a/test/ddc-regress/core/05-Machine/10-Prep/Test.stdout.check
+++ b/test/ddc-regress/core/05-Machine/10-Prep/Test.stdout.check
@@ -10,7 +10,7 @@ ok
 -- forward recursive definitions.
 -- Another pass that converts non-recursive letrecs into lets would be ideal.
 module Map 
-export value exec       : Source# a0 -> Sink# c0 -> Process#;
+export value Main.exec : Source# a0 -> Sink# c0 -> Process#;
 import foreign abstract type
         a0 : Data;
 
@@ -20,8 +20,8 @@ import foreign abstract type
 import foreign abstract type
         c0 : Data;
 
-import value f0         : a0 -> b0;
-import value g0         : b0 -> c0;
+import value Base.f0    : a0 -> b0;
+import value Base.g0    : b0 -> c0;
 with
 let exec: Source# a0 -> Sink# c0 -> Process#
       = process_1_1# [a0] [c0]

--- a/test/ddc-regress/core/05-Machine/20-Slurp/Test.dcx
+++ b/test/ddc-regress/core/05-Machine/20-Slurp/Test.dcx
@@ -9,11 +9,12 @@ import foreign abstract type
     a0 : Data
     b0 : Data
     c0 : Data
-import value
-    f0 : a0 -> b0
-    g0 : b0 -> c0
 
-export exec : Source# a0 -> Sink# c0 -> Process#
+import value
+    Base.f0 : a0 -> b0
+    Base.g0 : b0 -> c0
+
+export value Map.exec : Source# a0 -> Sink# c0 -> Process#
 
 with
 let     map [a b : Data] (f : a -> b) (as : Stream# a) : Tuple1# (Stream# b)
@@ -37,10 +38,11 @@ module Map
 
 import foreign abstract type
     int : Data
-import value
-    plus : int -> int -> int
 
-export exec : Source# int -> Sink# int -> Process#
+import value
+    Base.plus : int -> int -> int
+
+export Map.exec : Source# int -> Sink# int -> Process#
 
 with
 let     scannish (as : Stream# int) : Tuple1# (Stream# int)

--- a/test/ddc-regress/core/05-Machine/30-Fused/Test.dcx
+++ b/test/ddc-regress/core/05-Machine/30-Fused/Test.dcx
@@ -9,11 +9,12 @@ import foreign abstract type
     a0 : Data
     b0 : Data
     c0 : Data
-import value
-    f0 : a0 -> b0
-    g0 : b0 -> c0
 
-export exec : Source# a0 -> Sink# c0 -> Process#
+import value
+    Base.f0 : a0 -> b0
+    Base.g0 : b0 -> c0
+
+export Map.exec : Source# a0 -> Sink# c0 -> Process#
 
 with
 let     map [a b : Data] (f : a -> b) (as : Stream# a) : Tuple1# (Stream# b)

--- a/test/ddc-spec/error/01-ErrorExp/03-ExportMismatch/Main.dcs
+++ b/test/ddc-spec/error/01-ErrorExp/03-ExportMismatch/Main.dcs
@@ -6,7 +6,7 @@ module Main
 
 -- Export the main entry point.
 --   Exported type does not match defined type.
-export main  : [r1: Region]. Int#
+export Main.main  : [r1: Region]. Int#
 
 -- Primitive show functions are defined in the runtime system.
 import foreign c value


### PR DESCRIPTION
Add module qualifiers to exported names, so the symbols don't clash with ones in the standard C library.